### PR TITLE
fix hardcoded interface

### DIFF
--- a/roles/rke2/files/rkeConfig.j2
+++ b/roles/rke2/files/rkeConfig.j2
@@ -1,6 +1,6 @@
 # Managed by Ansible
-{% if hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] != hostvars[groups['servers'][0]]['ansible_eth0']['ipv4']['address'] %}
-server: https://{{ hostvars[groups['servers'][0]]['ansible_eth0']['ipv4']['address']}}:9345
+{% if hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] != hostvars[groups['servers'][0]]['ansible_default_ipv4']['address'] %}
+server: https://{{ hostvars[groups['servers'][0]]['ansible_default_ipv4']['address']}}:9345
 {% endif %}
 {% if clusterconfig.token is defined  %}
 token: {{ clusterconfig.token }}

--- a/roles/rke2/tasks/installServer.yaml
+++ b/roles/rke2/tasks/installServer.yaml
@@ -3,17 +3,17 @@
   template:
     src: files/rkeConfig.j2
     dest: /etc/rancher/rke2/config.yaml
-  when: hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] == hostvars[groups['servers'][0]]['ansible_eth0']['ipv4']['address']
+  when: hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] == hostvars[groups['servers'][0]]['ansible_default_ipv4']['address']
 
 
 - name: Install RKE2 on first master
   shell: curl -sfL https://get.rke2.io | sh -s - --cluster-init
-  when: hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] == hostvars[groups['servers'][0]]['ansible_eth0']['ipv4']['address'] and clusterconfig.kubernetesVersion is not defined
+  when: hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] == hostvars[groups['servers'][0]]['ansible_default_ipv4']['address'] and clusterconfig.kubernetesVersion is not defined
   register: rkeinstall
 
 - name: Install RKE2 on first master with version
   shell: curl -sfL https://get.rke2.io | INSTALL_RKE2_CHANNEL={{clusterconfig.kubernetesVersion}} sh -s - --cluster-init
-  when: hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] == hostvars[groups['servers'][0]]['ansible_eth0']['ipv4']['address'] and clusterconfig.kubernetesVersion is defined
+  when: hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] == hostvars[groups['servers'][0]]['ansible_default_ipv4']['address'] and clusterconfig.kubernetesVersion is defined
   register: rkeinstallv
 
 - name: start rke2-server
@@ -28,27 +28,26 @@
 - name: Wait for node-token
   wait_for:
     path: "/var/lib/rancher/rke2/server/node-token"
-  when: hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] == hostvars[groups['servers'][0]]['ansible_eth0']['ipv4']['address'] and clusterconfig.token is not defined
+  when: hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] == hostvars[groups['servers'][0]]['ansible_default_ipv4']['address'] and clusterconfig.token is not defined
 
 - name: Read node-token from master
   slurp:
     path: "/var/lib/rancher/rke2/server/node-token"
   register: node_token
-  when: hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] == hostvars[groups['servers'][0]]['ansible_eth0']['ipv4']['address'] and clusterconfig.token is not defined
+  when: hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] == hostvars[groups['servers'][0]]['ansible_default_ipv4']['address'] and clusterconfig.token is not defined
 
 - name: Create RKE2 config on other masters
   template:
     src: files/rkeConfig.j2
     dest: /etc/rancher/rke2/config.yaml
-  when: hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] != hostvars[groups['servers'][0]]['ansible_eth0']['ipv4']['address']
+  when: hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] != hostvars[groups['servers'][0]]['ansible_default_ipv4']['address']
 
-- name: Install RKE2 on other Master nodes 
+- name: Install RKE2 on other Master nodes
   shell: curl -sfL https://get.rke2.io | sh -s - --cluster-init
-  when: hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] != hostvars[groups['servers'][0]]['ansible_eth0']['ipv4']['address'] and clusterconfig.kubernetesVersion is not defined
+  when: hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] != hostvars[groups['servers'][0]]['ansible_default_ipv4']['address'] and clusterconfig.kubernetesVersion is not defined
   notify: start rke2-server
 
 - name: Install RKE2 on other Master nodes with version
   shell: curl -sfL https://get.rke2.io | INSTALL_RKE2_CHANNEL={{clusterconfig.kubernetesVersion}} sh -s - --cluster-init
-  when: hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] != hostvars[groups['servers'][0]]['ansible_eth0']['ipv4']['address'] and clusterconfig.kubernetesVersion is defined
+  when: hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] != hostvars[groups['servers'][0]]['ansible_default_ipv4']['address'] and clusterconfig.kubernetesVersion is defined
   notify: start rke2-server
-

--- a/roles/rke2/tasks/main.yaml
+++ b/roles/rke2/tasks/main.yaml
@@ -7,7 +7,7 @@
 
 - name: Install kubevip
   include: installKubevip.yaml
-  when: clusterconfig.kubevip.enabled is true and hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] == hostvars[groups['servers'][0]]['ansible_eth0']['ipv4']['address']
+  when: clusterconfig.kubevip.enabled is true and hostvars[inventory_hostname]['ansible_facts']['default_ipv4']['address'] == hostvars[groups['servers'][0]]['ansible_default_ipv4']['address']
 
 - name: Install server nodes
   include: installServer.yaml


### PR DESCRIPTION
Before this commit _ansible_eth0_ was used, which caused the playbook to fail on systems, which had another name for the network interface. 
To solve this _hostvars[groups['servers'][0]]['ansible_eth0']['ipv4']['address']_ has been replaced by _hostvars[groups['servers'][0]]['ansible_default_ipv4']['address']_, which uses the default IPv4 address of the system, don't matter what the interface name is.